### PR TITLE
Fix windows build

### DIFF
--- a/cgogn/geometry/algos/ear_triangulation.h
+++ b/cgogn/geometry/algos/ear_triangulation.h
@@ -32,6 +32,8 @@
 #include <cgogn/geometry/types/vector_traits.h>
 
 #include <set>
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 namespace cgogn
 {

--- a/cgogn/modeling/algos/graph_to_hex.cpp
+++ b/cgogn/modeling/algos/graph_to_hex.cpp
@@ -57,7 +57,10 @@
 
 #include <fstream>
 #include <iostream>
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include <numeric>
+
 
 namespace cgogn
 {

--- a/cgogn/ui/modules/surface_deformation/surface_deformation.h
+++ b/cgogn/ui/modules/surface_deformation/surface_deformation.h
@@ -38,6 +38,8 @@
 #include <Eigen/Sparse>
 #include <boost/synapse/connect.hpp>
 #include <memory>
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 namespace cgogn
 {

--- a/thirdparty/imgui/CMakeLists.txt
+++ b/thirdparty/imgui/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cgogn/thirdparty>
 )
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_IMPL_OPENGL_LOADER_GL3W NOMINMAX)
 if (NOT MSVC)
     target_link_libraries(${PROJECT_NAME} PUBLIC glfw dl)
 else()


### PR DESCRIPTION
Hello, I have been trying to compile examples on windows and faced some errors:

* Need to force imgui to use gl3w via a compile definition: if glad is installed on the system it has the priority in imgui_impl_opengl3.h
* gl3w includes windows.h without NOMINMAX by default which creates conflict with std::min/std::max via the rendering module
* Some math constants M_PI, M_PI_2 used without the math include. (Used math.h here to keep the header with other system header, using cmath instead would require [to put it on top of the list](https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio))

The PR fixed it on my machine. (clang 10.0 and vs2019 16.6.5)